### PR TITLE
Bugfix/qhull_error_line (#5)

### DIFF
--- a/hmeasure/hsource.py
+++ b/hmeasure/hsource.py
@@ -18,17 +18,21 @@ from sklearn.metrics import roc_curve
 
 
 def _generate_B_coefs(a, b, n0, n1):
+
     pi1 = n1 / (n1 + n0)
     b10 = beta_func((1+a), b)
     b01 = beta_func(a, (1+b))
     b00 = beta_func(a, b)
+
     B0 = beta_dist.cdf(x=pi1, a=(1+a), b=b) * b10/b00
     B1 = (beta_dist.cdf(x=1, a=a, b=(1+b)) -
           beta_dist.cdf(x=pi1, a=a, b=(1+b))) * b01/b00
+
     return B0, B1
 
 
 def _generate_LH_coef(n0, n1, G0, G1, b0, b1):
+
     pi1 = n1 / (n1 + n0)
     pi0 = n0 / (n1 + n0)
     b0_head = b0[1:]
@@ -43,11 +47,14 @@ def _generate_LH_coef(n0, n1, G0, G1, b0, b1):
 
 
 def _generate_b_vecs(cost, a, b):
+
     b10 = beta_func((1+a), b)
     b01 = beta_func(a, (1+b))
     b00 = beta_func(a, b)
-    b0 = beta_dist.cdf(x=cost, a=(1 + a), b=b) * b10 / b00
-    b1 = beta_dist.cdf(x=cost, a=a, b=(1 + b)) * b01 / b00
+
+    b0 = beta_dist.cdf(x=cost, a=(1 + a), b=b) * ( b10 / b00 )
+    b1 = beta_dist.cdf(x=cost, a=a, b=(1 + b)) * ( b01 / b00 )
+
     return b0, b1
 
 
@@ -58,8 +65,8 @@ def _generate_cost(n0, n1, G0: numpy.ndarray, G1: numpy.ndarray):
     G0_head = G0[1:]
     G0_norm = G0[:-1]
 
-    c1 = n1 / (n1 + n0) * (G1_head - G1_norm)
-    c0 = n0 / (n1 + n0) * (G0_head - G0_norm)
+    c1 = ( n1 / (n1 + n0) ) * ( G1_head - G1_norm )
+    c0 = ( n0 / (n1 + n0) ) * ( G0_head - G0_norm )
 
     c_more = c1 / (c1 + c0)
 
@@ -69,6 +76,7 @@ def _generate_cost(n0, n1, G0: numpy.ndarray, G1: numpy.ndarray):
 
 
 def _generate_beta_params(n0, n1, sev_ratio):
+
     if sev_ratio is None:
         sr = n1 / n0
     else:
@@ -81,34 +89,53 @@ def _generate_beta_params(n0, n1, sev_ratio):
         b = n0/(n0+n1) + 1
     else:
         raise ValueError
+
     return a, b
 
 
 def _generate_convex_hull_points(invF0: numpy.ndarray, invF1: numpy.ndarray):
-    pair_max = numpy.maximum(invF0, invF1)
-    try:
-        chull_cand = numpy.array(list(zip(invF0, pair_max)))
-    except Exception as e:
-        print(list(zip(invF0, pair_max)))
-        raise e
 
-    hull = ConvexHull(chull_cand)
-    G0 = numpy.sort(invF0[hull.vertices])
-    G1 = numpy.sort(invF1[hull.vertices])
+    pair_max = numpy.maximum(invF0, invF1)
+
+    # if all invF0>=invF1, pair_max = invF0
+    # chull_cand is a line and
+    # ConvexHull results in QHullError
+    if not numpy.array_equal(invF0, pair_max):
+        chull_cand = numpy.array(list(zip(invF0, pair_max)))
+        hull = ConvexHull(chull_cand)
+        vert = hull.vertices
+
+        G0 = numpy.sort(invF0[vert])
+        G1 = numpy.sort(invF1[vert])
+
+    else:
+        G0 = numpy.array([0, 1])
+        G1 = numpy.array([0, 1])
+
     return G0, G1
 
 
-def _generate_h_measure(n0, n1, B0, B1, LH):
-    return 1 - (LH / ((n0*B0 + n1*B1)/(n0+n1)))
+def _generate_h_measure(n0, n1, B0, B1, LH, fix_prec = True):
+
+    j = (LH * (n0+n1))
+    k = (n0*B0 + n1*B1)
+
+    # due to floating point imprecision
+    # set lower bound at 0
+    if fix_prec and numpy.isclose(j, k) and j > k:
+        j = k
+
+    return 1 - numpy.divide(j, k)
 
 
 def _transform_roc_to_invF(fpr_untr: numpy.ndarray, tpr_untr: numpy.ndarray):
     fpr = -numpy.sort(-fpr_untr)
+    tpr = -numpy.sort(-tpr_untr)
+
     # extend vector with explicit (0, 0)
     fpr = numpy.concatenate([fpr, [0]])
-    tpr = -numpy.sort(-tpr_untr)
-    # extend vector with explicit (0, 0)
     tpr = numpy.concatenate([tpr, [0]])
+
     return fpr, tpr
 
 
@@ -184,6 +211,7 @@ def h_score(y_true: numpy.ndarray, y_score: numpy.ndarray,
 
     if pos_label is None:
         pos_label = 1.
+
     # make y_true a boolean vector
     y_true = (y_true == pos_label)
 
@@ -194,8 +222,8 @@ def h_score(y_true: numpy.ndarray, y_score: numpy.ndarray,
 
     G0, G1 = _generate_convex_hull_points(fpr, tpr)
 
-    n1 = sum(y_true)
-    n0 = len(y_true) - n1
+    n1 = y_true.sum()
+    n0 = y_true.shape[0] - n1
 
     a, b = _generate_beta_params(n0=n0, n1=n1, sev_ratio=severity_ratio)
     cost = _generate_cost(n0=n0, n1=n1, G0=G0, G1=G1)
@@ -204,5 +232,6 @@ def h_score(y_true: numpy.ndarray, y_score: numpy.ndarray,
     LH = _generate_LH_coef(n0=n0, n1=n1, G0=G0, G1=G1, b0=b0, b1=b1)
     B0, B1 = _generate_B_coefs(a=a, b=b, n0=n0, n1=n1)
 
-    h_score = _generate_h_measure(n0=n0, n1=n1, B0=B0, B1=B1, LH=LH)
+    h_score = _generate_h_measure(n0=n0, n1=n1, B0=B0, B1=B1, LH=LH, fix_prec=True)
+
     return h_score

--- a/hmeasure/tests/test_hmeasure.py
+++ b/hmeasure/tests/test_hmeasure.py
@@ -119,6 +119,21 @@ def test__generate_h_measure(case_data):
 
     assert numpy.isclose(exp_H, H)
 
+def test__generate_h_measure_negative():
+    n0 = 1
+    n1 = 1
+    B0 = 0.1
+    B1 = 0.1
+    LH = 0.1000000001
+
+    exp_H = 0
+    H0 = _generate_h_measure(n0=n0, n1=n1, B0=B0, B1=B1, LH=LH, fix_prec=False)
+    H1 = _generate_h_measure(n0=n0, n1=n1, B0=B0, B1=B1, LH=LH, fix_prec=True)
+
+    # test that H0 is a very small negative value
+    assert exp_H > H0 and numpy.isclose(exp_H, H0)
+    assert exp_H == H1
+
 
 def test__generate_convex_hull_points(case_data):
     invF0 = case_data['invF0']
@@ -131,6 +146,16 @@ def test__generate_convex_hull_points(case_data):
     assert numpy.allclose(G0, exp_G0)
     assert numpy.allclose(G1, exp_G1)
 
+def test__generate_convex_hull_points_exception():
+    invF0 = numpy.array([0,0.1,0.2,0.3,0.4,1])
+    invF1 = numpy.array([0,0.01,0.02,0.03,0.04,1])
+
+    exp_G0 = numpy.array([0, 1])
+    exp_G1 = numpy.array([0, 1])
+    G0, G1 = _generate_convex_hull_points(invF0, invF1)
+
+    assert numpy.allclose(G0, exp_G0)
+    assert numpy.allclose(G1, exp_G1)
 
 def test__transform_roc_to_invF(case_data):
     y_true = case_data['y_true']


### PR DESCRIPTION
* error found: qhull exception in _generate_convex_hull_points when (invF0>invF1).all() <> line segment; fixed by returning (0,0) and (1,1) points; fix introduced very small negative values of h_score, h_score now has limit at 0